### PR TITLE
fix(controller): correct variable naming for slug validation in detai…

### DIFF
--- a/applications/modules/news/controller/news_controller.moon
+++ b/applications/modules/news/controller/news_controller.moon
@@ -30,7 +30,7 @@ class NewsController extends System.BaseController
 
     detail: (application) =>
         slug = application.params.slug
-        is valid, result = @validate_slug
+        is_valid, result = @validate_slug
 
         unless is_valid
             application.locals = {


### PR DESCRIPTION
This pull request makes a minor change to the `NewsController` class in the `applications/modules/news/controller/news_controller.moon` file. The variable name `is valid` was corrected to `is_valid` to fix a naming inconsistency.